### PR TITLE
Deprecate change-task-progress action

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,10 @@ jobs:
       - uses: nbycomp/asana-github-actions@master
         with:
           asana-pat: ${{ secrets.ASANA_TOKEN }}
-          action: 'update-custom-field'
+          action: "update-custom-field"
           field-name: "Github PR"
           trigger-phrase: "\\*\\*Asana Task:\\*\\*"
-          content: 'https://github.com/${{github.repository}}/pull/${{github.event.pull_request.number}}'
+          content: "https://github.com/${{github.repository}}/pull/${{github.event.pull_request.number}}"
 ```
 
 ```yaml
@@ -206,9 +206,9 @@ jobs:
       - uses: nbycomp/asana-github-actions@master
         with:
           asana-pat: ${{ secrets.ASANA_TOKEN }}
-          action: 'change-task-progress'
+          action: "change-task-progress"
           trigger-phrase: "\\*\\*Asana Task:\\*\\*"
-          state: 'Waiting'
+          state: "Waiting"
 ```
 
 ## Testing
@@ -217,7 +217,7 @@ Tests can be run using `npm test`.
 
 The tests connect to a running instance of Asana, and create/modify tasks inside a project
 called "Asana bot test environment". This project must be created in advance,
-with two sections: "New" and "Done".
+with three sections: "Todo", "Waiting" and "Done".
 
 The following environment variables must be set:
 

--- a/action.js
+++ b/action.js
@@ -46,7 +46,7 @@ async function moveSection(client, taskId, targets) {
         return client.sections
           .addTask(targetSection.gid, { task: taskId })
           .then(() =>
-            core.info(`Moved to: ${target.project}/${target.section}`)
+            core.info(`Moved to: ${targetProject.name}/${target.section}`)
           );
       } else {
         core.error(`Asana section ${target.section} not found.`);

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,13 @@ inputs:
     required: false
     default: false
   targets:
-    description: 'JSON array of objects having project and section where to move current task. Move task only if it exists in target project.'
+    description: >
+      JSON array of objects having project and section where to move current task.
+      Move task only if it exists in target project.
+      Use with "move-sections" action.
+    required: false
+  targetSection:
+    description: 'Name of section to move Asana task to. Use with "move-section" action'
     required: false
   link-required:
     description: 'When set to true will fail pull requests without an asana link'
@@ -33,7 +39,7 @@ inputs:
     description: 'Is the task complete'
     required: false
 branding:
-  icon: 'chevron-right'  
+  icon: 'chevron-right'
   color: 'gray-dark'
 runs:
   using: 'node12'


### PR DESCRIPTION
**Asana Task:** https://app.asana.com/0/1204557849295745/1205529600356709

Since we have reorganised our Asana board, move-section should be used instead. Display a warning message in the action.

A follow-up task will be to change the Asana action to use move-section instead of change-task-progress.